### PR TITLE
Update pickerios.md

### DIFF
--- a/docs/pickerios.md
+++ b/docs/pickerios.md
@@ -9,6 +9,7 @@ title: PickerIOS
 
 * [`itemStyle`](pickerios.md#itemstyle)
 * [`onValueChange`](pickerios.md#onvaluechange)
+* [`onChange`](pickerios.md#onChange)
 * [`selectedValue`](pickerios.md#selectedvalue)
 
 ---
@@ -33,8 +34,16 @@ title: PickerIOS
 
 ---
 
+### `onChange`
+
+| Type     | Required |
+| -------- | -------- |
+| function | No       |
+
+---
+
 ### `selectedValue`
 
-| Type | Required |
-| ---- | -------- |
-| any  | No       |
+| Type              | Required |
+| ---------------   | -------- |
+| number or string  | No       |


### PR DESCRIPTION
This is part of #929

## was added
- The [`onChange`](https://github.com/facebook/react-native/blob/master/Libraries/Components/Picker/PickerIOS.ios.js#L61) prop

### was updated
- The [`selectedValue`](https://github.com/facebook/react-native/blob/master/Libraries/Components/Picker/PickerIOS.ios.js#L63) allowed types

### notes

> I do not know if I'm right, but I think the properties of **onChange** and **onValueChange** have exactly the same

![image](https://user-images.githubusercontent.com/20761166/59458408-618bed00-8de8-11e9-860a-b1cff44ba83c.png)

> In this image you can notice that the native component is only passing as property **onChange** and it calls **_onChange** which in turn executes the method **onValueChange** or **onChange**

![image](https://user-images.githubusercontent.com/20761166/59458456-78cada80-8de8-11e9-96b7-c0243b93e798.png)

<!--
Thank you for the PR! Contributors like you keep React Native awesome!

Please see the Contribution Guide for guidelines:

https://github.com/facebook/react-native-website/blob/master/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below:

#<Issue>
-->
